### PR TITLE
[LKB-6575] feat: enable CPK for some operations

### DIFF
--- a/sdk/storage_blobs/src/blob/operations/get_blob.rs
+++ b/sdk/storage_blobs/src/blob/operations/get_blob.rs
@@ -45,7 +45,7 @@ impl GetBlobBuilder {
                 }
 
                 headers.add(this.lease_id);
-                headers.add(this.encryption_key.as_ref());
+                headers.add(this.encryption_key.clone());
                 headers.add(this.if_modified_since);
                 headers.add(this.if_match.clone());
                 headers.add(this.if_tags.clone());

--- a/sdk/storage_blobs/src/blob/operations/get_blob.rs
+++ b/sdk/storage_blobs/src/blob/operations/get_blob.rs
@@ -45,7 +45,7 @@ impl GetBlobBuilder {
                 }
 
                 headers.add(this.lease_id);
-                headers.add(this.encryption_key.clone());
+                headers.add(this.encryption_key.as_ref());
                 headers.add(this.if_modified_since);
                 headers.add(this.if_match.clone());
                 headers.add(this.if_tags.clone());

--- a/sdk/storage_blobs/src/blob/operations/get_properties.rs
+++ b/sdk/storage_blobs/src/blob/operations/get_properties.rs
@@ -5,6 +5,7 @@ use time::OffsetDateTime;
 operation! {
     GetProperties,
     client: BlobClient,
+    ?encryption_key: CPKInfo,
     ?if_modified_since: IfModifiedSinceCondition,
     ?if_match: IfMatchCondition,
     ?if_tags: IfTags,
@@ -20,6 +21,7 @@ impl GetPropertiesBuilder {
             self.blob_versioning.append_to_url_query(&mut url);
 
             let mut headers = Headers::new();
+            headers.add(self.encryption_key);
             headers.add(self.lease_id);
             headers.add(self.if_modified_since);
             headers.add(self.if_match);

--- a/sdk/storage_blobs/src/blob/operations/put_block.rs
+++ b/sdk/storage_blobs/src/blob/operations/put_block.rs
@@ -9,6 +9,7 @@ operation! {
     block_id: BlockId,
     body: Body,
     ?hash: Hash,
+    ?encryption_key: CPKInfo,
     ?lease_id: LeaseId
 }
 
@@ -21,6 +22,8 @@ impl PutBlockBuilder {
             url.query_pairs_mut().append_pair("comp", "block");
 
             let mut headers = Headers::new();
+            headers.add(self.hash);
+            headers.add(self.encryption_key);
             headers.add(self.lease_id);
 
             let mut request = BlobClient::finalize_request(

--- a/sdk/storage_blobs/src/blob/operations/put_block_list.rs
+++ b/sdk/storage_blobs/src/blob/operations/put_block_list.rs
@@ -18,6 +18,7 @@ operation! {
     ?metadata: Metadata,
     ?access_tier: AccessTier,
     ?tags: Tags,
+    ?encryption_key: CPKInfo,
     ?lease_id: LeaseId,
     ?if_modified_since: IfModifiedSinceCondition,
     ?if_match: IfMatchCondition,
@@ -57,6 +58,7 @@ impl PutBlockListBuilder {
                 }
             }
             headers.add(self.access_tier);
+            headers.add(self.encryption_key);
             headers.add(self.lease_id);
             headers.add(self.if_modified_since);
             headers.add(self.if_match);


### PR DESCRIPTION
- Enable CPK for the operations we used in remote_storage crate.
- `copy` is not supported - Azure doc doesn't say how to provide encryption keys for that. Trying to figure out later.
- Looks like the current version of SDK has a bug with put block where `hash` isn't properly added. Fixed it along the way.