### PR TITLE
expose x-ms-encryption-context on HeadPathResponse

### DIFF
--- a/sdk/core/src/headers/mod.rs
+++ b/sdk/core/src/headers/mod.rs
@@ -391,6 +391,7 @@ pub const USER_AGENT: HeaderName = HeaderName::from_static("user-agent");
 pub const VERSION: HeaderName = HeaderName::from_static("x-ms-version");
 pub const WWW_AUTHENTICATE: HeaderName = HeaderName::from_static("www-authenticate");
 pub const ENCRYPTION_ALGORITHM: HeaderName = HeaderName::from_static("x-ms-encryption-algorithm");
+pub const ENCRYPTION_CONTEXT: HeaderName = HeaderName::from_static("x-ms-encryption-context");
 pub const ENCRYPTION_KEY: HeaderName = HeaderName::from_static("x-ms-encryption-key");
 pub const ENCRYPTION_KEY_SHA256: HeaderName = HeaderName::from_static("x-ms-encryption-key-sha256");
 pub const SOURCE_ENCRYPTION_ALGORITHM: HeaderName =

--- a/sdk/storage_datalake/src/operations/path_head.rs
+++ b/sdk/storage_datalake/src/operations/path_head.rs
@@ -48,6 +48,13 @@ pub struct HeadPathResponse {
     pub last_modified: OffsetDateTime,
     pub properties: Option<Properties>,
     pub acl: Option<String>,
+    /// `x-ms-encryption-context` — opaque, base64-encoded on the wire.
+    /// The DFS endpoint serves this without requiring the CPK key in
+    /// the request (unlike the blob endpoint), which is the typical
+    /// reason a caller invokes `head().action(GetStatus)` on an
+    /// encrypted blob. Returned as the raw base64 string; callers
+    /// decode as needed.
+    pub encryption_context: Option<String>,
 }
 
 impl HeadPathResponse {
@@ -62,6 +69,7 @@ impl HeadPathResponse {
             content_type: headers.get_optional_as(&headers::CONTENT_TYPE)?,
             properties: headers.get_optional_as(&headers::PROPERTIES)?,
             acl: headers.get_optional_string(&headers::ACL),
+            encryption_context: headers.get_optional_string(&headers::ENCRYPTION_CONTEXT),
         })
     }
 }


### PR DESCRIPTION
Adds the `x-ms-encryption-context` header as an optional field on `HeadPathResponse` so callers of `head().action(GetStatus)` can read the value without going around the typed response and reaching back into the raw HTTP headers.

## Why

ADLS Gen2 serves `x-ms-encryption-context` on DFS HEAD without requiring the CPK key in the request — unlike the blob endpoint, which won't return the header (or any content) without CPK. That's the standard pattern for recovering a wrapped per-file key on an encrypted blob: HEAD the DFS endpoint, parse `x-ms-encryption-context`, unwrap. Today the operation strips that header from the response and callers have no way to retrieve it through the SDK, forcing them to re-implement the HEAD via raw HTTP just to read one header. This is the immediate use case in `hadron/libs/remote_storage/src/azure_hns_copy.rs` which currently maintains ~150 LOC of raw-`reqwest` DFS HEAD plumbing purely because of this missing field.

## Summary

- New header constant `ENCRYPTION_CONTEXT` in `azure_core` next to the existing `ENCRYPTION_KEY` / `ENCRYPTION_ALGORITHM` constants.
- New `encryption_context: Option<String>` field on `HeadPathResponse`, populated from the header by `try_from`. Exposed as the raw base64 string (matching how `acl` is exposed) — callers decode as needed.

## Test plan

- [x] `cargo build -p azure_storage_datalake` (verified locally; the change is mechanical: one constant, one struct field, one extraction line).
- [x] `cargo fmt --check`
- [x] `cargo clippy --tests -p azure_storage_datalake -- -D warnings`