### PR TITLE
[LKB-12485] feat(storage_blobs): add Undelete Blob operation

### DIFF
--- a/sdk/storage_blobs/src/blob/operations/mod.rs
+++ b/sdk/storage_blobs/src/blob/operations/mod.rs
@@ -30,6 +30,7 @@ mod set_metadata;
 mod set_properties;
 mod set_tags;
 mod snapshot_blob;
+mod undelete_blob;
 
 pub use acquire_lease::*;
 pub use append_block::*;
@@ -63,3 +64,4 @@ pub use set_metadata::*;
 pub use set_properties::*;
 pub use set_tags::*;
 pub use snapshot_blob::*;
+pub use undelete_blob::*;

--- a/sdk/storage_blobs/src/blob/operations/undelete_blob.rs
+++ b/sdk/storage_blobs/src/blob/operations/undelete_blob.rs
@@ -1,0 +1,29 @@
+use crate::prelude::*;
+use azure_core::{headers::*, RequestId};
+use time::OffsetDateTime;
+
+operation! {
+    UndeleteBlob,
+    client: BlobClient,
+}
+
+impl UndeleteBlobBuilder {
+    pub fn into_future(mut self) -> UndeleteBlob {
+        Box::pin(async move {
+            let mut url = self.client.url()?;
+
+            url.query_pairs_mut().append_pair("comp", "undelete");
+
+            let mut request =
+                BlobClient::finalize_request(url, azure_core::Method::Put, Headers::new(), None)?;
+
+            let response = self.client.send(&mut self.context, &mut request).await?;
+            UndeleteBlobResponse::from_headers(response.headers())
+        })
+    }
+}
+
+azure_storage::response_from_headers!(UndeleteBlobResponse,
+    request_id_from_headers => request_id: RequestId,
+    date_from_headers => date: OffsetDateTime
+);

--- a/sdk/storage_blobs/src/clients/blob_client.rs
+++ b/sdk/storage_blobs/src/clients/blob_client.rs
@@ -165,6 +165,12 @@ impl BlobClient {
         DeleteBlobVersionBuilder::new(self.clone(), version_id)
     }
 
+    /// Restore a soft-deleted blob, reviving all of its soft-deleted versions
+    /// and snapshots. Requires a storage account with soft delete enabled.
+    pub fn undelete(&self) -> UndeleteBlobBuilder {
+        UndeleteBlobBuilder::new(self.clone())
+    }
+
     /* Operations specific to certain blob types */
 
     /// Creates a new block to be committed as part of a block blob.


### PR DESCRIPTION
## What

Adds `BlobClient::undelete()`, which issues the Azure [`Undelete Blob`](https://learn.microsoft.com/en-us/rest/api/storageservices/undelete-blob) REST request (`PUT {blob}?comp=undelete`) to restore a soft-deleted blob and all of its soft-deleted versions and snapshots.

## Why

`storage_blobs` exposes `delete` / `delete_version_id` / `snapshot` but had no way to revive a soft-deleted blob. This is needed for time-travel / point-in-time recovery on storage accounts with versioning + soft delete enabled: a soft-deleted version cannot be used as a copy source until the blob is undeleted.

## Implementation

Modeled on the existing comp-based blob operations:
- New `blob/operations/undelete_blob.rs` — the `operation!` macro generates the builder; `into_future` issues the `PUT` with `comp=undelete` and an empty body via `finalize_request`; `UndeleteBlobResponse` (via `response_from_headers!`) exposes `request_id` and `date`.
- Registered in `blob/operations/mod.rs`.
- `BlobClient::undelete()` added alongside the delete family.

The operation is intentionally header-light: per the REST spec, Undelete Blob accepts no conditional headers and no lease id, so the builder has no optional fields. `x-ms-undelete-source` is hierarchical-namespace-only (the HNS data plane lives in `storage_datalake`, and no blob operation models HNS headers), so it is deliberately omitted for flat-namespace consistency.

## Verification

`cargo check -p azure_storage_blobs --no-default-features --features enable_reqwest` compiles cleanly with no new warnings from the crate.
